### PR TITLE
 Stop game when GameOver instance is show

### DIFF
--- a/Scripts/GameStructure/Levels/LevelManager.cs
+++ b/Scripts/GameStructure/Levels/LevelManager.cs
@@ -191,6 +191,7 @@ namespace GameFramework.GameStructure.Levels
 
             SecondsRunning = 0f;
             IsLevelStarted = true;
+            Time.timeScale = 1.0f;
         }
 
         [Obsolete("Call StartLevel() instead.")]
@@ -285,6 +286,7 @@ namespace GameFramework.GameStructure.Levels
         {
             yield return new WaitForSeconds(delay);
             UI.Dialogs.Components.GameOver.Instance.Show(isWon);
+            Time.timeScale = 0.0f;
         }
 
 


### PR DESCRIPTION
Hi, 

I think Game should be stopped when  UI.Dialogs.Components.GameOver.Instance.Show(isWon) is shown.

We can't use PauseLevel() method because of restart Button on GameOver Dialog.

What do you think ? 

/br Greg

