### PR TITLE
Update FacebookManager.cs

### DIFF
--- a/Scripts/Facebook/Components/FacebookManager.cs
+++ b/Scripts/Facebook/Components/FacebookManager.cs
@@ -762,6 +762,7 @@ namespace GameFramework.Facebook.Components
                         }
                     }else if (to != null && to.Type == JSONValueType.String)
                     {
+                         NumberOfInvitesSent++;
                         InvitedFriends.Add(to.Str);
                         Debug.Log("Value: " + value.Str);
                     }


### PR DESCRIPTION
If you only send one app request the "to" value in the returned JSON is a string not an array of one. This change corrects a reference not set to an instance of an object exception in that instance.

You get this from Facebook
{"to":"1534995506528760","request":"655925497912303","callback_id":"4"}

but the code was expecting
{"to":["1534995506528760"],"request":"655925497912303","callback_id":"4"}